### PR TITLE
Rename context from exercises to activities

### DIFF
--- a/lib/fitstr/activities/activities.ex
+++ b/lib/fitstr/activities/activities.ex
@@ -1,12 +1,12 @@
-defmodule Fitstr.Exercises do
+defmodule Fitstr.Activities do
   @moduledoc """
-  The Exercises context.
+  The Activities context.
   """
 
   import Ecto.Query, warn: false
   alias Fitstr.Repo
 
-  alias Fitstr.Exercises.Movement
+  alias Fitstr.Activities.Movement
 
   @doc """
   Returns the list of movements.

--- a/lib/fitstr/activities/movement.ex
+++ b/lib/fitstr/activities/movement.ex
@@ -1,7 +1,7 @@
-defmodule Fitstr.Exercises.Movement do
+defmodule Fitstr.Activities.Movement do
   use Ecto.Schema
   import Ecto.Changeset
-  alias Fitstr.Exercises.Movement
+  alias Fitstr.Activities.Movement
 
 
   schema "movements" do

--- a/lib/fitstr_web/controllers/movement_controller.ex
+++ b/lib/fitstr_web/controllers/movement_controller.ex
@@ -1,21 +1,21 @@
 defmodule FitstrWeb.MovementController do
   use FitstrWeb, :controller
 
-  alias Fitstr.Exercises
-  alias Fitstr.Exercises.Movement
+  alias Fitstr.Activities
+  alias Fitstr.Activities.Movement
 
   def index(conn, _params) do
-    movements = Exercises.list_movements()
+    movements = Activities.list_movements()
     render(conn, "index.html", movements: movements)
   end
 
   def new(conn, _params) do
-    changeset = Exercises.change_movement(%Movement{})
+    changeset = Activities.change_movement(%Movement{})
     render(conn, "new.html", changeset: changeset)
   end
 
   def create(conn, %{"movement" => movement_params}) do
-    case Exercises.create_movement(movement_params) do
+    case Activities.create_movement(movement_params) do
       {:ok, movement} ->
         conn
         |> put_flash(:info, "Movement created successfully.")
@@ -26,20 +26,20 @@ defmodule FitstrWeb.MovementController do
   end
 
   def show(conn, %{"id" => id}) do
-    movement = Exercises.get_movement!(id)
+    movement = Activities.get_movement!(id)
     render(conn, "show.html", movement: movement)
   end
 
   def edit(conn, %{"id" => id}) do
-    movement = Exercises.get_movement!(id)
-    changeset = Exercises.change_movement(movement)
+    movement = Activities.get_movement!(id)
+    changeset = Activities.change_movement(movement)
     render(conn, "edit.html", movement: movement, changeset: changeset)
   end
 
   def update(conn, %{"id" => id, "movement" => movement_params}) do
-    movement = Exercises.get_movement!(id)
+    movement = Activities.get_movement!(id)
 
-    case Exercises.update_movement(movement, movement_params) do
+    case Activities.update_movement(movement, movement_params) do
       {:ok, movement} ->
         conn
         |> put_flash(:info, "Movement updated successfully.")
@@ -50,8 +50,8 @@ defmodule FitstrWeb.MovementController do
   end
 
   def delete(conn, %{"id" => id}) do
-    movement = Exercises.get_movement!(id)
-    {:ok, _movement} = Exercises.delete_movement(movement)
+    movement = Activities.get_movement!(id)
+    {:ok, _movement} = Activities.delete_movement(movement)
 
     conn
     |> put_flash(:info, "Movement deleted successfully.")

--- a/test/fitstr/activities/activities_test.exs
+++ b/test/fitstr/activities/activities_test.exs
@@ -1,10 +1,10 @@
-defmodule Fitstr.ExercisesTest do
+defmodule Fitstr.ActivitiesTest do
   use Fitstr.DataCase
 
-  alias Fitstr.Exercises
+  alias Fitstr.Activities
 
   describe "movements" do
-    alias Fitstr.Exercises.Movement
+    alias Fitstr.Activities.Movement
 
     @valid_attrs %{description: "some description", name: "some name"}
     @update_attrs %{description: "some updated description", name: "some updated name"}
@@ -14,34 +14,34 @@ defmodule Fitstr.ExercisesTest do
       {:ok, movement} =
         attrs
         |> Enum.into(@valid_attrs)
-        |> Exercises.create_movement()
+        |> Activities.create_movement()
 
       movement
     end
 
     test "list_movements/0 returns all movements" do
       movement = movement_fixture()
-      assert Exercises.list_movements() == [movement]
+      assert Activities.list_movements() == [movement]
     end
 
     test "get_movement!/1 returns the movement with given id" do
       movement = movement_fixture()
-      assert Exercises.get_movement!(movement.id) == movement
+      assert Activities.get_movement!(movement.id) == movement
     end
 
     test "create_movement/1 with valid data creates a movement" do
-      assert {:ok, %Movement{} = movement} = Exercises.create_movement(@valid_attrs)
+      assert {:ok, %Movement{} = movement} = Activities.create_movement(@valid_attrs)
       assert movement.description == "some description"
       assert movement.name == "some name"
     end
 
     test "create_movement/1 with invalid data returns error changeset" do
-      assert {:error, %Ecto.Changeset{}} = Exercises.create_movement(@invalid_attrs)
+      assert {:error, %Ecto.Changeset{}} = Activities.create_movement(@invalid_attrs)
     end
 
     test "update_movement/2 with valid data updates the movement" do
       movement = movement_fixture()
-      assert {:ok, movement} = Exercises.update_movement(movement, @update_attrs)
+      assert {:ok, movement} = Activities.update_movement(movement, @update_attrs)
       assert %Movement{} = movement
       assert movement.description == "some updated description"
       assert movement.name == "some updated name"
@@ -49,19 +49,19 @@ defmodule Fitstr.ExercisesTest do
 
     test "update_movement/2 with invalid data returns error changeset" do
       movement = movement_fixture()
-      assert {:error, %Ecto.Changeset{}} = Exercises.update_movement(movement, @invalid_attrs)
-      assert movement == Exercises.get_movement!(movement.id)
+      assert {:error, %Ecto.Changeset{}} = Activities.update_movement(movement, @invalid_attrs)
+      assert movement == Activities.get_movement!(movement.id)
     end
 
     test "delete_movement/1 deletes the movement" do
       movement = movement_fixture()
-      assert {:ok, %Movement{}} = Exercises.delete_movement(movement)
-      assert_raise Ecto.NoResultsError, fn -> Exercises.get_movement!(movement.id) end
+      assert {:ok, %Movement{}} = Activities.delete_movement(movement)
+      assert_raise Ecto.NoResultsError, fn -> Activities.get_movement!(movement.id) end
     end
 
     test "change_movement/1 returns a movement changeset" do
       movement = movement_fixture()
-      assert %Ecto.Changeset{} = Exercises.change_movement(movement)
+      assert %Ecto.Changeset{} = Activities.change_movement(movement)
     end
   end
 end

--- a/test/fitstr_web/controllers/movement_controller_test.exs
+++ b/test/fitstr_web/controllers/movement_controller_test.exs
@@ -1,14 +1,14 @@
 defmodule FitstrWeb.MovementControllerTest do
   use FitstrWeb.ConnCase
 
-  alias Fitstr.Exercises
+  alias Fitstr.Activities
 
   @create_attrs %{description: "some description", name: "some name"}
   @update_attrs %{description: "some updated description", name: "some updated name"}
   @invalid_attrs %{description: nil, name: nil}
 
   def fixture(:movement) do
-    {:ok, movement} = Exercises.create_movement(@create_attrs)
+    {:ok, movement} = Activities.create_movement(@create_attrs)
     movement
   end
 


### PR DESCRIPTION
This will make it a little friendlier to support tracking of
non-exercise activities.